### PR TITLE
MISC-240 - use more standard versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <plugin>
           <groupId>com.goldin.plugins</groupId>
           <artifactId>maven-copy-plugin</artifactId>
-          <version>0.2-SNAPSHOT</version>
+          <version>0.2.2</version>
         </plugin>
         
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -288,9 +288,7 @@
     <dependency>
       <groupId>javax.el</groupId>
       <artifactId>el-api</artifactId>
-      <!-- honestly, this may be wrong.  Jboss hosts a 'javax.el:el-api:1.2' version, but no one else does, apparently...
-      Could be a revised implementation of the api that does more caching, etc.  -->
-      <version>1.2</version>
+      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
     


### PR DESCRIPTION
Small version tweaks to support https://jira.cru.org/browse/MISC-240

This PR is essentially identical to https://github.com/CruGlobal/eTimesheet/pull/5.